### PR TITLE
Pass in Riot API token instead of relying on environment variables

### DIFF
--- a/Sources/LOLAPIClient/LOLAPIClient.swift
+++ b/Sources/LOLAPIClient/LOLAPIClient.swift
@@ -14,8 +14,8 @@ public class LOLAPIClient {
     
     /// See: https://developer.riotgames.com/apis#summoner-v4/GET_getBySummonerName
     public func fetchSummoner(serverRegion: ServerRegion,
-                                     summonerName: String,
-                                     request: Request) async throws -> SummonerDTO {
+                              summonerName: String,
+                              request: Request) async throws -> SummonerDTO {
         let baseURL = Self.baseURL(for: serverRegion)
         let requestURI: URI = "\(baseURL)/lol/summoner/v4/summoners/by-name/\(summonerName)"
         let response = try await request.client.get(requestURI) { req in
@@ -33,8 +33,8 @@ public class LOLAPIClient {
     
     /// See: https://developer.riotgames.com/apis#champion-mastery-v4/GET_getAllChampionMasteriesByPUUID
     public func fetchChampionMasteries(serverRegion: ServerRegion,
-                                              puuid: String,
-                                              request: Request) async throws -> [ChampionMasteryDTO] {
+                                       puuid: String,
+                                       request: Request) async throws -> [ChampionMasteryDTO] {
         let baseURL = Self.baseURL(for: serverRegion)
         let requestURI: URI = "\(baseURL)/lol/champion-mastery/v4/champion-masteries/by-puuid/\(puuid)"
         let response = try await request.client.get(requestURI) { req in
@@ -52,9 +52,9 @@ public class LOLAPIClient {
     
     /// See: https://developer.riotgames.com/apis#champion-mastery-v4/GET_getChampionMasteryByPUUID
     public func fetchChampionMastery(serverRegion: ServerRegion,
-                                            puuid: String,
-                                            championId: ChampionID,
-                                            request: Request) async throws -> ChampionMasteryDTO {
+                                     puuid: String,
+                                     championId: ChampionID,
+                                     request: Request) async throws -> ChampionMasteryDTO {
         let baseURL = Self.baseURL(for: serverRegion)
         let requestURI: URI = "\(baseURL)/lol/champion-mastery/v4/champion-masteries/by-puuid/\(puuid)/by-champion/\(championId)"
         let response = try await request.client.get(requestURI) { req in

--- a/Sources/LOLAPIClient/LOLAPIClient.swift
+++ b/Sources/LOLAPIClient/LOLAPIClient.swift
@@ -1,17 +1,25 @@
 import Vapor
 
 public class LOLAPIClient {
+    let riotAPIToken: String
+    let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        return decoder
+    }()
+    
+    init(riotAPIToken: String) {
+        self.riotAPIToken = riotAPIToken
+    }
+    
     /// See: https://developer.riotgames.com/apis#summoner-v4/GET_getBySummonerName
-    public static func fetchSummoner(serverRegion: ServerRegion,
+    public func fetchSummoner(serverRegion: ServerRegion,
                                      summonerName: String,
                                      request: Request) async throws -> SummonerDTO {
-        guard let riotToken = Environment.get("X-Riot-Token") else {
-            throw Abort(.internalServerError)
-        }
-        let baseURL = baseURL(for: serverRegion)
+        let baseURL = Self.baseURL(for: serverRegion)
         let requestURI: URI = "\(baseURL)/lol/summoner/v4/summoners/by-name/\(summonerName)"
         let response = try await request.client.get(requestURI) { req in
-            req.headers.add(name: "X-Riot-Token", value: riotToken)
+            req.headers.add(name: "X-Riot-Token", value: riotAPIToken)
             req.headers.add(name: "Accept-Language", value: "en-US,en;q=0.7")
             req.headers.replaceOrAdd(name: "Accept", value: "application/json;charset=utf-8")
             req.headers.replaceOrAdd(name: "Content-Type", value: "application/json;charset=utf-8")
@@ -19,23 +27,18 @@ public class LOLAPIClient {
         guard response.status.isValid() else {
             throw Abort(response.status)
         }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .millisecondsSince1970
         let json = try response.content.decode(SummonerDTO.self, using: decoder)
         return json
     }
     
     /// See: https://developer.riotgames.com/apis#champion-mastery-v4/GET_getAllChampionMasteriesByPUUID
-    public static func fetchChampionMasteries(serverRegion: ServerRegion,
+    public func fetchChampionMasteries(serverRegion: ServerRegion,
                                               puuid: String,
                                               request: Request) async throws -> [ChampionMasteryDTO] {
-        guard let riotToken = Environment.get("X-Riot-Token") else {
-            throw Abort(.internalServerError)
-        }
-        let baseURL = baseURL(for: serverRegion)
+        let baseURL = Self.baseURL(for: serverRegion)
         let requestURI: URI = "\(baseURL)/lol/champion-mastery/v4/champion-masteries/by-puuid/\(puuid)"
         let response = try await request.client.get(requestURI) { req in
-            req.headers.add(name: "X-Riot-Token", value: riotToken)
+            req.headers.add(name: "X-Riot-Token", value: riotAPIToken)
             req.headers.add(name: "Accept-Language", value: "en-US,en;q=0.7")
             req.headers.replaceOrAdd(name: "Accept", value: "application/json;charset=utf-8")
             req.headers.replaceOrAdd(name: "Content-Type", value: "application/json;charset=utf-8")
@@ -43,24 +46,19 @@ public class LOLAPIClient {
         guard response.status.isValid() else {
             throw Abort(response.status)
         }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .millisecondsSince1970
         let json = try response.content.decode([ChampionMasteryDTO].self, using: decoder)
         return json
     }
     
     /// See: https://developer.riotgames.com/apis#champion-mastery-v4/GET_getChampionMasteryByPUUID
-    public static func fetchChampionMastery(serverRegion: ServerRegion,
+    public func fetchChampionMastery(serverRegion: ServerRegion,
                                             puuid: String,
                                             championId: ChampionID,
                                             request: Request) async throws -> ChampionMasteryDTO {
-        guard let riotToken = Environment.get("X-Riot-Token") else {
-            throw Abort(.internalServerError)
-        }
-        let baseURL = baseURL(for: serverRegion)
+        let baseURL = Self.baseURL(for: serverRegion)
         let requestURI: URI = "\(baseURL)/lol/champion-mastery/v4/champion-masteries/by-puuid/\(puuid)/by-champion/\(championId)"
         let response = try await request.client.get(requestURI) { req in
-            req.headers.add(name: "X-Riot-Token", value: riotToken)
+            req.headers.add(name: "X-Riot-Token", value: riotAPIToken)
             req.headers.add(name: "Accept-Language", value: "en-US,en;q=0.7")
             req.headers.replaceOrAdd(name: "Accept", value: "application/json;charset=utf-8")
             req.headers.replaceOrAdd(name: "Content-Type", value: "application/json;charset=utf-8")
@@ -68,13 +66,11 @@ public class LOLAPIClient {
         guard response.status.isValid() else {
             throw Abort(response.status)
         }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .millisecondsSince1970
         let json = try response.content.decode(ChampionMasteryDTO.self, using: decoder)
         return json
     }
     
-    public static func fetchChampions(request: Request) async throws -> ChampionsResponse {
+    public func fetchChampions(request: Request) async throws -> ChampionsResponse {
         let requestURI: URI = "https://ddragon.leagueoflegends.com/cdn/13.24.1/data/en_US/champion.json"
         let response = try await request.client.get(requestURI)
         guard response.status.isValid() else {

--- a/Sources/LOLAPIClient/LOLAPIClient.swift
+++ b/Sources/LOLAPIClient/LOLAPIClient.swift
@@ -8,7 +8,7 @@ public class LOLAPIClient {
         return decoder
     }()
     
-    init(riotAPIToken: String) {
+    public init(riotAPIToken: String) {
         self.riotAPIToken = riotAPIToken
     }
     


### PR DESCRIPTION
- Changed `LOLAPIClient` to a class that you have to instantiate
- Changed `riotAPIToken` to a stored property in the `LOLAPIClient` class
- Have one instance of `JSONDecoder` in the `LOLAPIClient` class
- Updated request methods to not be static methods