### PR TITLE
Added rudimentary ETag support for the data dragon champion JSON asset

### DIFF
--- a/Sources/LOLAPIClient/ResponseCache/FetchChampionsResponseCache.swift
+++ b/Sources/LOLAPIClient/ResponseCache/FetchChampionsResponseCache.swift
@@ -1,0 +1,15 @@
+//
+//  FetchChampionsResponseCache.swift
+//
+//
+//  Created by Andreas Hård on 2024-02-03.
+//
+
+import Foundation
+import Vapor
+
+struct FetchChampionsResponseCache: CachedResponseItem {
+    var requestURI: URI
+    var eTag: String
+    var response: ChampionsResponse
+}

--- a/Sources/LOLAPIClient/ResponseCache/InMemoryCache.swift
+++ b/Sources/LOLAPIClient/ResponseCache/InMemoryCache.swift
@@ -1,0 +1,53 @@
+//
+//  InMemoryCache.swift
+//
+//
+//  Created by Andreas Hård on 2024-02-03.
+//
+
+import Foundation
+import Vapor
+
+protocol CachedResponseItem {
+    associatedtype ResponseType: Codable
+    
+    var requestURI: URI { get }
+    var eTag: String { get }
+    var response: ResponseType { get }
+}
+
+class InMemoryCache {
+    private(set) var cachedItems: [any CachedResponseItem] = []
+    
+    init() {
+        
+    }
+    
+    func cachedItem(for requestURI: URI) -> (any CachedResponseItem)? {
+        guard let cachedItem = cachedItems
+            .filter({ $0.requestURI.string == requestURI.string })
+            .first else {
+                return nil
+            }
+        return cachedItem
+    }
+    
+    func addCachedItem(cachedItem: any CachedResponseItem) {
+        if let cachedItemTuple = cachedItems
+            .enumerated()
+            .filter({ $0.element.requestURI.string == cachedItem.requestURI.string })
+            .first {
+            cachedItems.remove(at: cachedItemTuple.offset)
+        }
+        cachedItems.append(cachedItem)
+    }
+    
+    func eTag(for requestURI: URI) -> String? {
+        guard let cachedItem = cachedItem(for: requestURI) else {
+            return nil
+        }
+        return cachedItem.eTag
+    }
+    
+    
+}


### PR DESCRIPTION
* Added `InMemoryCache` class that stores `cachedItems` in array of any type that conforms to the `CachedResponseItem` protocol
* Added `FetchChampionsResponseCache` struct that conforms to the `CachedResponseItem`
* Updated the `fetchChampions(request: Request)` method to store the JSON response in the `InMemoryCache` class and return it if we receive a 304 `.notModified` HTTP Response

**Please observe:**
This is still a very rudimentary implementation. There's no [LRU cache](https://en.wikipedia.org/wiki/Cache_replacement_policies#least-recently-used) implemented meaning that the cache can grow indefinitely in size.